### PR TITLE
Improve honeypot detection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     mead (0.1.0)
+      hashie
 
 GEM
   remote: https://rubygems.org/
@@ -73,6 +74,7 @@ GEM
     erubi (1.11.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     loofah (2.19.0)

--- a/lib/mead/form_helper.rb
+++ b/lib/mead/form_helper.rb
@@ -1,7 +1,19 @@
 module ActionView
   module Helpers
     module FormHelper
-      # Creates a honeypot on forms that will be appropriately namespaced
+      # Creates a honeypot on forms that will be appropriately namespaced.
+      #
+      # Returns a FormHelper tag of type +form_tag+ that will be namespaced
+      # via the +object_name+ and that will use the hash of +options+.
+      # Allows you to declare a +name+, or if nil grabs a pseudo-random
+      # name. Also allows you to pass in a hash of +options+
+      # that will be passed to the +form_tag+.
+      # Takes a +form_tag+ as a string or symbol, the +object_name+ as a string
+      # or symbol, a +name+ as a string or symbol, a hash of +options+ that will
+      # be passed to the +form_tag+, and an optional +block+.
+      #
+      # If you pass in a +block+ you will have access to the pre-made tag and the
+      # pseudo-randomly created name.
       #
       # ==== Examples
       #
@@ -27,7 +39,12 @@ module ActionView
         end
       end
 
-      # Creates an obfuscation on forms that will be appropriately namespaced
+      # Creates an obfuscation on forms that will be appropriately namespaced.
+      #
+      # Returns an input tag of type +input_type+ that will get the +method+ value
+      # from the +object_name+ that is passed in. Can alternatively be provided with
+      # a +block+ that will give the user access to a pre-made input tag, the
+      # obfuscated name, and the name of the +method+ that was passed in.
       #
       # ==== Examples
       #

--- a/mead.gemspec
+++ b/mead.gemspec
@@ -8,13 +8,11 @@ Gem::Specification.new do |spec|
   spec.authors       = ["cwagrant"]
   spec.email         = ["cwagrant@gmail.com"]
 
-  spec.summary       = "Easy way to add honeypot fields to existing forms."
-  spec.description   = "This description is shorter out of spite."
-  spec.homepage      = "https://github.com/cwagrant/EasyDestroy"
+  spec.summary       = "Makes it easy to add honeypots to your forms and obfuscate your params"
+  spec.description   = "To help with keep the bots at bay this gem helps you easily add honeypots to forms and/or obfuscate your form field names"
+  spec.homepage      = "https://github.com/cwagrant/mead"
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 2.4.0"
-
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -40,6 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "railties", [">= 0"]
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-html-matchers"
+
+  spec.add_dependency "hashie"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
To make the detection of postive honeypot fields easier on the user this commit adds the Hashie gem and makes use of deep_find to more easily locate positive honeypots inside the params hash without requiring users to manually dictate where in the params we should check.