### PR TITLE
Add Configurability

### DIFF
--- a/lib/mead.rb
+++ b/lib/mead.rb
@@ -1,127 +1,55 @@
 # frozen_string_literal: true
 
+require 'mead/configuration'
 require_relative 'mead/version'
 require 'mead/form_tag_helper'
 require 'mead/form_helper'
 require 'mead/engine'
+require 'mead/helpers'
 require 'hashie'
 
 class NoAvailableHoneypotFieldNames < StandardError; end
 
 module Mead
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
   def self.included(base)
     helper_methods = self.protected_instance_methods
 
     base.send :helper_method, helper_methods
-  end
 
-  def honeypot_present?
-    honeypot_params = params.permit!.to_hash
+    if base.respond_to? :before_action
+      base.send :prepend_before_action, :on_honeypot_failure, self.protect_controller_actions
 
-    honeypot_params.extend Hashie::Extensions::DeepFind
-
-    honeypot_field_names.each do |honeypot|
-      return true if honeypot_params.deep_find(honeypot).present?
-    end
-
-    false
-  rescue StandardError
-    false
-  end
-
-  def mead_params(requires: nil)
-    masked = params
-
-    if requires.is_a? Array
-      masked = requires.reduce(params) { |acc, requirement| acc.require(requirement) }
-    elsif requires.present?
-      masked = masked.require(requires)
-    end
-
-    masked.permit!.reduce({}) do |acc, masked_value|
-      decrypted = deobfuscate_value(masked_value.first)
-      next acc if decrypted.nil?
-
-      acc[decrypted] = masked_value.last
-
-      acc
+    elsif base.respond_to? :before_filter
+      base.send :prepend_before_filter, :on_honeypot_failure, self.protect_controller_actions
     end
   end
 
-  protected
-  # Each of the below methods can be overwritten. Of note are
-  # the *_attributes methods which can be used to easily customize
-  # the options of the <div>, <label>, and <input> fields.
-  #
-  # You can also provide your own custom list of honeypot field names
-  # by writing your own honeypot_field_names method.
+  def self.protect_controller_actions
+    options = {}
 
-  def mead_field_name
-    @mead_field_names ||= honeypot_field_names
+    if configuration.protect_controller_actions.present?
+      options[:only] = configuration.protect_controller_actions
+    end
 
-    raise NoAvailableHoneypotFieldNames if @mead_field_names.empty?
+    if configuration.ignore_controller_actions.present?
+      options[:except] = configuration.ignore_controller_actions
+    end
 
-    @mead_field_names.delete @mead_field_names.sample
-  end
+    puts configuration
+    puts options
 
-  def mead_wrapper_attributes
-    {
-      aria: { hidden: true},
-      class: 'mead-style-attributes'
-    }
-  end
-
-  def mead_input_attributes
-    {
-      aria: { hidden: true},
-      class: 'mead-style-attributes',
-      tabindex: -1
-    }
-  end
-
-  def mead_label_attributes
-    {
-      aria: { hidden: true},
-      tabindex: -1
-    }
-  end
-
-  def honeypot_field_names
-    %w(
-      secret
-      passphrase
-      real_password
-      a_password
-      your_comments
-      a_comment
-    )
-  end
-
-  def mead_obfuscate_field(name)
-    real_name = extract_name(name.to_s)
-    encrypted = obfuscate_value(real_name)
-
-    name.to_s.gsub(/#{real_name}/, encrypted)
-  end
-
-  private
-
-  def obfuscate_value(value)
-    hash = {value: value, random: SecureRandom.hex(12)}
-    Base64.urlsafe_encode64(JSON.dump(hash))
-  end
-
-  def deobfuscate_value(value)
-    hash = JSON.load(Base64.urlsafe_decode64(value))
-    hash['value']
-  rescue
-    nil
-  end
-
-  def extract_name(name)
-    real_name = name.scan(/\[[^\[\]]+\]/).last || name
-    real_name.tr('[]', '')
+    options
   end
 end
-
-ActionController::Base.send(:include, Mead) if defined?(ActionController::Base)

--- a/lib/mead/configuration.rb
+++ b/lib/mead/configuration.rb
@@ -1,0 +1,10 @@
+module Mead
+  class Configuration
+    attr_accessor :protect_controller_actions, :ignore_controller_actions
+
+    def initialize
+      @protect_controller_actions = nil
+      @ignore_controller_actions = nil
+    end
+  end
+end

--- a/lib/mead/helpers.rb
+++ b/lib/mead/helpers.rb
@@ -1,0 +1,141 @@
+module Mead
+  module Helpers
+    def self.included(base)
+      helper_methods = self.protected_instance_methods
+
+      base.send :helper_method, helper_methods
+    end
+
+    def on_honeypot_failure
+      head :ok if honeypot_present?
+    end
+
+    def honeypot_present?
+      honeypot_params = params.permit!.to_hash
+
+      honeypot_params.extend Hashie::Extensions::DeepFind
+
+      honeypot_field_names.each do |honeypot|
+        return true if honeypot_params.deep_find(honeypot).present?
+      end
+
+      false
+    rescue StandardError
+      false
+    end
+
+    def mead_params(requires: nil)
+      masked = params
+
+      if requires.is_a? Array
+        masked = requires.reduce(params) { |acc, requirement| acc.require(requirement) }
+      elsif requires.present?
+        masked = masked.require(requires)
+      end
+
+      masked.permit!.reduce({}) do |acc, masked_value|
+        decrypted = deobfuscate_value(masked_value.first)
+        next acc if decrypted.nil?
+
+        acc[decrypted] = masked_value.last
+
+        acc
+      end
+    end
+
+    protected
+    # Each of the below methods can be overwritten. Of note are
+    # the *_attributes methods which can be used to easily customize
+    # the options of the <div>, <label>, and <input> fields.
+    #
+    # You can also provide your own custom list of honeypot field names
+    # by writing your own honeypot_field_names method.
+
+    def mead_field_name
+      @mead_field_names ||= honeypot_field_names
+
+      raise NoAvailableHoneypotFieldNames if @mead_field_names.empty?
+
+      @mead_field_names.delete @mead_field_names.sample
+    end
+
+    def mead_wrapper_attributes
+      {
+        aria: { hidden: true},
+        class: 'mead-style-attributes'
+      }
+    end
+
+    def mead_input_attributes
+      {
+        aria: { hidden: true},
+        class: 'mead-style-attributes',
+        tabindex: -1
+      }
+    end
+
+    def mead_label_attributes
+      {
+        aria: { hidden: true},
+        tabindex: -1
+      }
+    end
+
+    def honeypot_field_names
+      %w(
+        secret
+        passphrase
+        real_password
+        a_password
+        your_comments
+        a_comment
+      )
+    end
+
+    def mead_obfuscate_field(name)
+      real_name = extract_name(name.to_s)
+      encrypted = obfuscate_value(real_name)
+
+      name.to_s.gsub(/#{real_name}/, encrypted)
+    end
+
+    private
+
+    def obfuscate_value(value)
+      hash = {value: value, random: SecureRandom.hex(12)}
+      Base64.urlsafe_encode64(JSON.dump(hash))
+    end
+
+    def deobfuscate_value(value)
+      hash = JSON.load(Base64.urlsafe_decode64(value))
+      hash['value']
+    rescue
+      nil
+    end
+
+    def extract_name(name)
+      real_name = name.scan(/\[[^\[\]]+\]/).last || name
+      real_name.tr('[]', '')
+    end
+
+    def self.protect_controller_actions
+      options = {}
+
+      if configuration.protect_controller_actions.present?
+        options[:only] = configuration.protect_controller_actions
+      end
+
+      if configuration.ignore_controller_actions.present?
+        options[:except] = configuration.ignore_controller_actions
+      end
+
+      puts configuration
+      puts options
+
+      options
+    end
+  end
+end
+
+# This will give access to the views/tags to any of the above needed public/protected methods.
+ActionController::Base.send(:include, Mead::Helpers) if defined?(ActionController::Base)


### PR DESCRIPTION
This commit breaks out the helper methods into their own sub-module `Mead::Helpers` and adds the ability to configure what actions the honeypot check occurs on via configuration.

E.g.
```ruby
Mead.configure do |config|
  config.protect_controller_actions = [:create, :update, :foo]
  config.ignore_controller_actions = [:new, :edit, :bar]
end
```