### PR TITLE
Update param deobfuscation to be more natural

### DIFF
--- a/lib/mead.rb
+++ b/lib/mead.rb
@@ -7,6 +7,7 @@ require 'mead/form_helper'
 require 'mead/engine'
 require 'mead/helpers'
 require 'hashie'
+require 'json'
 
 class NoAvailableHoneypotFieldNames < StandardError; end
 
@@ -41,14 +42,9 @@ module Mead
 
     if configuration.protect_controller_actions.present?
       options[:only] = configuration.protect_controller_actions
-    end
-
-    if configuration.ignore_controller_actions.present?
+    elsif configuration.ignore_controller_actions.present?
       options[:except] = configuration.ignore_controller_actions
     end
-
-    puts configuration
-    puts options
 
     options
   end


### PR DESCRIPTION
In order to make the accessing of masked params this commit updates the mead_params method so that instead of accessing very specific sections of your params it will instead recursively check all of the params (ActionController::Parameters) for keys that are obfuscated, deobfuscate them, and then finally returns a new ActionController::Parameters object with the cleaned up params.

Functionally anyone should be able to use mead_params the way they would params.