### PR TITLE
Upgrade to make work with Rails 5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    mead_captcha (0.1.2)
+    mead_captcha (1.0.0)
+      actionview (> 5.2, <= 7.0)
       hashie
 
 GEM
@@ -85,9 +86,11 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.15.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -163,14 +166,14 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  -darwin-22
   x86_64-darwin-20
 
 DEPENDENCIES
-  actionview
   mead_captcha!
   pry
-  rails (> 4.0)
-  railties
+  rails (> 5.2, <= 7.0)
+  railties (>= 5.2)
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec-html-matchers

--- a/lib/mead_captcha/form_helper.rb
+++ b/lib/mead_captcha/form_helper.rb
@@ -93,7 +93,8 @@ module ActionView
             @unchecked_value = options.fetch('unchecked_value') { '0' }
           end
 
-          options['value'] = options.fetch('value') { value_before_type_cast(object) }
+          options['value'] = options.fetch('value') { value_before_type_cast }
+
           add_default_name_and_id(options)
 
           options.delete 'obfuscated_name'

--- a/lib/mead_captcha/version.rb
+++ b/lib/mead_captcha/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MeadCaptcha
-  VERSION = "0.1.3"
+  VERSION = "1.0.0"
 end

--- a/mead_captcha.gemspec
+++ b/mead_captcha.gemspec
@@ -30,17 +30,15 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
   #
-  spec.add_development_dependency "actionview"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rails", ">4.0"
-  spec.add_development_dependency "rspec-rails"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "railties", [">= 0"]
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-html-matchers"
-
+  spec.add_dependency "actionview", "> 5.2", "<= 7.0"
   spec.add_dependency "hashie"
 
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rails", "> 5.2", "<= 7.0"
+  spec.add_development_dependency "rspec-rails"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "railties", ">= 5.2"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec-html-matchers"
 end
+

--- a/spec/mead_spec.rb
+++ b/spec/mead_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe MeadCaptcha do
         expect(html).to have_tag("label[for=#{@helpers.mead_field_name}]")
       end
     end
+
+    describe :mead_obfuscate do
+      let(:widget) { double }
+
+      before do
+        allow(widget).to receive(:foo).and_return('bar')
+      end
+
+      it 'creates an obfuscated field' do
+        html = @helpers.mead_obfuscate(:text_box, :widget, :foo )
+        expect(html).to have_tag("input[type=text_box]")
+        expect(html).to have_tag("input[id^=widget]")
+      end
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rails'
 require 'active_support'
 require 'action_view'
 require 'action_controller'
+require 'active_record'
 require 'rspec-html-matchers'
 require "mead_captcha"
 
@@ -39,5 +40,9 @@ class TestView < ActionView::Base
   def initialize(controller_path = nil, action = nil)
     @controller = TestController.new
   end
+end
+
+class TestWidget
+  attr_accessor :foo
 end
 


### PR DESCRIPTION
In order to accomodate changes made with how form helpers work in 5.2 this commit makes it so that the call to value_before_type_cast is no longer passed an object.