### PR TITLE
Fix Load Order

### DIFF
--- a/lib/mead_captcha.rb
+++ b/lib/mead_captcha.rb
@@ -22,6 +22,8 @@ module MeadCaptcha
 
   def self.configure
     yield(configuration)
+
+    ActionController::Base.send(:include, MeadCaptcha) if defined?(ActionController::Base)
   end
 
   def self.included(base)
@@ -30,7 +32,7 @@ module MeadCaptcha
     base.send :helper_method, helper_methods
 
     if base.respond_to? :before_action
-      base.send :prepend_before_action, :on_honeypot_failure, self.protect_controller_actions
+      base.send :prepend_before_action, :on_honeypot_failure, **self.protect_controller_actions
 
     elsif base.respond_to? :before_filter
       base.send :prepend_before_filter, :on_honeypot_failure, self.protect_controller_actions
@@ -49,5 +51,3 @@ module MeadCaptcha
     options
   end
 end
-
-ActionController::Base.send(:include, MeadCaptcha) if defined?(ActionController::Base)

--- a/lib/mead_captcha/version.rb
+++ b/lib/mead_captcha/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MeadCaptcha
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
In order to make sure we get the configuration information before attaching to the ActionController we need to actually go through the configuration process. This means that we'll no longer be auto-loaded going forward but that is probalby for the best.

Now users will either have to define a mead_captcha.rb file in the initializers or they will need to manually include MeadCaptcha in their controller they wish to protect. This should help us avoid issues where controller actions we don't care about aren't 'proteted'.